### PR TITLE
feat: Remove Gmail SMTP integration, keep 8n8 webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ temp/
 
 # TypeScript
 *.tsbuildinfo
+.vercel


### PR DESCRIPTION
- Remove api/send-email.js and api/send-email.ts (SMTP endpoints)
- Remove nodemailer and @types/nodemailer dependencies
- Update vercel.json to remove SMTP API build configuration
- Update VERCEL_DEPLOYMENT_GUIDE.md to remove SMTP references
- Preserve 8n8 webhook integration (contactApi.ts)
- Contact form now uses 8n8 exclusively for email processing

Breaking changes:
- Removed Gmail SMTP functionality
- Removed /api/send-email endpoint
- Updated deployment guide for 8n8-only setup

Fixes:
- Resolves SSL certificate issues
- Simplifies deployment process
- Reduces dependencies and complexity