### PR TITLE
Update Get In Touch functionality and change Book to Schedule Discove…

### DIFF
--- a/docs/guides/crisp-ai-agent-setup.md
+++ b/docs/guides/crisp-ai-agent-setup.md
@@ -44,10 +44,10 @@ intent: super_urgent
 ## **💬 Step 3: Create AI Agent Responses**
 
 ### **3.1 Discovery Call Initial Response**
-**Trigger**: When user clicks "Book Discovery Call" button
+**Trigger**: When user clicks "Schedule Discovery Call" button
 **Response**:
 ```
-Hi! I see you're interested in booking a discovery call. I can help you schedule this right away.
+Hi! I see you're interested in scheduling a discovery call. I can help you schedule this right away.
 
 Would you prefer to:
 1. 📞 Have a phone call with our security expert
@@ -222,7 +222,7 @@ If you serve multiple countries, set up language detection:
 
 **English Response**:
 ```
-Hi! I can help you book a discovery call...
+Hi! I can help you schedule a discovery call...
 ```
 
 **German Response**:

--- a/docs/guides/crisp-trigger-plan.md
+++ b/docs/guides/crisp-trigger-plan.md
@@ -9,10 +9,10 @@ This plan outlines multiple strategic entry points to trigger the Crisp AI Agent
 
 ### **1.1 Discovery Call Buttons**
 **Location**: Hero Section, CTA Section
-**Trigger**: "Book a discovery call" / "Schedule Now"
+**Trigger**: "Schedule a discovery call" / "Schedule Now"
 **AI Agent Prompt**: 
 ```
-"Hi! I see you're interested in booking a discovery call. I can help you schedule this right away. 
+"Hi! I see you're interested in scheduling a discovery call. I can help you schedule this right away. 
 
 Would you prefer to:
 1. 📞 Have a phone call with our security expert

--- a/docs/test-plans/component-test-plan.md
+++ b/docs/test-plans/component-test-plan.md
@@ -277,7 +277,7 @@ This document outlines the testing approach for each component during the migrat
 - [ ] **Headline**: "Don't Wait for Your Next Breach or Audit" displays correctly
 - [ ] **Subline**: "Join leading enterprises who trust Hermes Security..." displays correctly
 - [ ] **CTA Options**: Only 2 CTAs (reduced from 3)
-- [ ] **Primary CTA**: "Book a Discovery Call" launches contact form
+- [ ] **Primary CTA**: "Schedule a Discovery Call" launches contact form
 - [ ] **Secondary CTA**: "Start a Pen Test Today" launches contact form
 
 #### Functional Tests

--- a/docs/test-plans/contact-form-test-plan.md
+++ b/docs/test-plans/contact-form-test-plan.md
@@ -87,7 +87,7 @@ This document outlines the testing approach for the Hermes Security contact form
 **Priority: High**
 
 #### **Test Cases**
-- [ ] **"Book a Discovery Call"** button navigates to contact form
+- [ ] **"Schedule a Discovery Call"** button navigates to contact form
 - [ ] **"Start a Pen Test Today"** button navigates to contact form
 - [ ] **No Crisp Chat**: Crisp chat does not open
 

--- a/docs/test-plans/discovery-call-test-plan.md
+++ b/docs/test-plans/discovery-call-test-plan.md
@@ -54,14 +54,14 @@ const testUsers = {
 
 **Test Steps**:
 1. Navigate to homepage
-2. Click "Book a Discovery Call" button in Hero Section
+2. Click "Schedule a Discovery Call" button in Hero Section
 3. Verify Crisp chat window opens
 4. Verify trigger message is sent
 5. Verify session data is set correctly
 
 **Expected Results**:
 - ✅ Chat window opens within 2 seconds
-- ✅ Message appears: "Hi! I see you're interested in booking a discovery call..."
+- ✅ Message appears: "Hi! I see you're interested in scheduling a discovery call..."
 - ✅ Session data includes: `context: discovery_call`, `intent: high_value`
 - ✅ No JavaScript errors in console
 
@@ -70,7 +70,7 @@ const testUsers = {
 // Test different discovery call buttons
 test("Hero Section Discovery Call Button - Slide 1", () => {
   navigateToHeroSlide(0); // Root causes slide
-  clickButton("Book a discovery call");
+  clickButton("Schedule a discovery call");
   expect(chatWindow).toBeVisible();
   expect(triggerMessage).toContain("discovery call");
   expect(sessionData.context).toBe("discovery_call");
@@ -78,7 +78,7 @@ test("Hero Section Discovery Call Button - Slide 1", () => {
 
 test("Hero Section Discovery Call Button - Slide 2", () => {
   navigateToHeroSlide(1); // Fix asymmetry slide
-  clickButton("Book a discovery call");
+  clickButton("Schedule a discovery call");
   expect(chatWindow).toBeVisible();
   expect(triggerMessage).toContain("discovery call");
   expect(sessionData.context).toBe("discovery_call");
@@ -109,8 +109,8 @@ test("CTA Section Discovery Call Button", () => {
 **Objective**: Test all discovery call buttons across the site
 
 **Test Locations**:
-- [ ] Hero Section - "Book a discovery call" (Slide 1: Root causes)
-- [ ] Hero Section - "Book a discovery call" (Slide 2: Fix asymmetry)
+- [ ] Hero Section - "Schedule a discovery call" (Slide 1: Root causes)
+- [ ] Hero Section - "Schedule a discovery call" (Slide 2: Fix asymmetry)
 - [ ] Hero Section - "See how we run an engagement" (Slide 3: Old way)
 - [ ] Hero Section - "Download our methodology one-pager" (Slide 4: Alerts to action)
 - [ ] CTA Section - "Schedule Now"
@@ -288,7 +288,7 @@ test("Keyboard Services Navigation", () => {
 
 **Expected Message**:
 ```
-Hi! I see you're interested in booking a discovery call. I can help you schedule this right away.
+Hi! I see you're interested in scheduling a discovery call. I can help you schedule this right away.
 
 Would you prefer to:
 1. 📞 Have a phone call with our security expert

--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -5,9 +5,9 @@ import { TriggerHandlers } from "@/utils/crispTriggers";
 const ctaOptions = [
   {
     icon: Calendar,
-    title: "Book a Discovery Call",
+    title: "Schedule a Discovery Call",
     description: "Discuss your security needs with our experts",
-    buttonText: "Book a Discovery Call",
+    buttonText: "Schedule a Discovery Call",
     variant: "hero" as const,
     primary: true
   },
@@ -59,7 +59,7 @@ export default function CTASection() {
                 className="w-full group"
                 size="lg"
                 onClick={() => {
-                  if (cta.title === "Book a Discovery Call") {
+                  if (cta.title === "Schedule a Discovery Call") {
                     TriggerHandlers.contactForm(cta.title);
                   } else if (cta.title === "Start a Pen Test Today") {
                     TriggerHandlers.contactForm(cta.title);

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -97,13 +97,18 @@ export default function ContactForm({ onSuccess, ctaSource }: ContactFormProps) 
     // Reset form to empty state for production
     reset(defaultFormData);
     
+    // Clear any error states
+    setSubmitError(null);
+    setCaptchaError(null);
+    setCaptchaToken(null);
+    
     // CTA source is now passed as a prop, no need to read from sessionStorage
     // Only log once to avoid spam
     if (!window.contactFormCtaLogged) {
       console.log('✅ ContactForm: Received CTA source from parent:', ctaSource);
       window.contactFormCtaLogged = true;
     }
-  }, [reset]); // Remove ctaSource from dependencies to prevent loop
+  }, [reset, ctaSource]); // Include ctaSource to reset when it changes
 
 
   const handleTermsChange = (checked: boolean) => {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -105,9 +105,14 @@ export default function Header() {
             <Button 
               variant="hero" 
               size="sm"
-              asChild
+              onClick={() => {
+                // Set CTA source to 'Get In Touch'
+                sessionStorage.setItem('cta-source', 'Get In Touch');
+                // Reload the page to /contact
+                window.location.href = '/contact';
+              }}
             >
-              <Link to="/contact">Get In Touch</Link>
+              Get In Touch
             </Button>
           </div>
 
@@ -155,11 +160,15 @@ export default function Header() {
                 <Button 
                   variant="hero" 
                   size="sm"
-                  asChild
+                    onClick={() => {
+                      setMobileMenuOpen(false);
+                      // Set CTA source to 'Get In Touch'
+                      sessionStorage.setItem('cta-source', 'Get In Touch');
+                      // Reload the page to /contact
+                      window.location.href = '/contact';
+                    }}
                 >
-                  <Link to="/contact" onClick={() => setMobileMenuOpen(false)}>
-                    Get In Touch
-                  </Link>
+                  Get In Touch
                 </Button>
               </div>
             </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -13,7 +13,8 @@ import { ContactFormData } from "@/services/contactApi";
 export default function Contact() {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [formData, setFormData] = useState<ContactFormData | null>(null);
-  const [ctaSource, setCtaSource] = useState<string>("Book Your Pen Test Today");
+  const [ctaSource, setCtaSource] = useState<string>("Get In Touch");
+  const [formKey, setFormKey] = useState<number>(0);
 
   // Get CTA source from sessionStorage (only run once)
   useEffect(() => {
@@ -34,10 +35,13 @@ export default function Contact() {
     } else {
       // Only log this once too
       if (!window.contactPageDefaultLogged) {
-        console.log('⚠️ Contact page: No CTA source found, using default:', ctaSource);
+        console.log('⚠️ Contact page: No CTA source found, using default: Get In Touch');
         window.contactPageDefaultLogged = true;
       }
     }
+    
+    // Reset form key to force form reset
+    setFormKey(prev => prev + 1);
   }, []); // Remove ctaSource dependency to prevent loop
 
   const handleFormSuccess = (data: ContactFormData) => {
@@ -170,7 +174,11 @@ export default function Contact() {
               </p>
             </div>
             
-            <ContactForm onSuccess={handleFormSuccess} ctaSource={ctaSource} />
+            <ContactForm 
+              key={`contact-form-${formKey}`} 
+              onSuccess={handleFormSuccess} 
+              ctaSource={ctaSource} 
+            />
           </div>
         </div>
         

--- a/src/utils/crispTriggers.ts
+++ b/src/utils/crispTriggers.ts
@@ -137,7 +137,7 @@ export const TriggerHandlers = {
       // Send initial message asking for phone number
       setTimeout(() => {
         CrispTriggers.sendMessage(
-          "Hi! I see you're interested in booking a discovery call. I can help you schedule this right away.\n\n" +
+          "Hi! I see you're interested in scheduling a discovery call. I can help you schedule this right away.\n\n" +
           "Would you prefer to:\n" +
           "1. 📞 Have a phone call with our security expert\n" +
           "2. 💬 Chat with us on WhatsApp\n" +
@@ -391,7 +391,7 @@ export const DiscoveryCallTriggers = {
     });
     
     const defaultMessage = 
-      "Hi! I see you're interested in booking a discovery call. I can help you schedule this right away.\n\n" +
+      "Hi! I see you're interested in scheduling a discovery call. I can help you schedule this right away.\n\n" +
       "Would you prefer to:\n" +
       "1. 📞 Have a phone call with our security expert\n" +
       "2. 💬 Chat with us on WhatsApp\n" +


### PR DESCRIPTION
…ry Call

- Modified Header component to reload page and clear form when Get In Touch is clicked
- Updated Contact page to default to 'Get In Touch' title
- Enhanced ContactForm to properly reset form values and error states
- Changed all references from 'Book a Discovery Call' to 'Schedule a Discovery Call'
- Updated CTA section, crisp triggers, and documentation files
- Fixed form reset mechanism with proper key management