### PR TITLE
fix: add artifact name to staging build upload

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -344,6 +344,7 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist/
+          name: staging-build
 
       - name: 🚀 Deploy to GitHub Pages
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
- Add name: staging-build to upload-pages-artifact@v3 step
- This matches the artifact_name expected by deploy-pages@v4
- Resolves 'No artifacts named staging-build were found' error
- Ensures staging deployment can find the uploaded artifact