### PR TITLE
hotfix: force GitHub Pages rebuild for staging deployment

### DIFF
--- a/HOTFIX_DEPLOYMENT.md
+++ b/HOTFIX_DEPLOYMENT.md
@@ -1,0 +1,1 @@
+# Hotfix deployment trigger - Fri Sep 19 21:11:47 SAST 2025


### PR DESCRIPTION
🔄 Triggering GitHub Pages rebuild to deploy contact form API endpoint fix
- Resolves 405 Method Not Allowed errors on staging
- Staging now uses 8n8 webhook instead of non-existent API endpoint
- Force deployment trigger: Fri Sep 19 21:12:03 SAST 2025